### PR TITLE
Libraries were updated to perform these scripts on Python 3.7 and Neo4j 3.4.17

### DIFF
--- a/glove_nn.py
+++ b/glove_nn.py
@@ -81,7 +81,7 @@ def macro_vertex(macro_vertex_label, round=None):
                 MATCH (cluster:Cluster {id: $clusterId, round: $round })-[:CONTAINS]->(token)
                 WITH cluster, collect(token) AS tokens
                 UNWIND tokens AS t1 UNWIND tokens AS t2 WITH t1, t2, cluster WHERE t1 <> t2
-                WITH t1, cluster, reduce(acc = 0, t2 in collect(t2) | acc + apoc.algo.euclideanDistance(t1.embedding, t2.embedding)) AS distance
+                WITH t1, cluster, reduce(acc = 0.0, t2 in collect(t2) | acc + apoc.algo.euclideanDistance(t1.embedding, t2.embedding)) AS distance
                 WITH t1, cluster, distance ORDER BY distance LIMIT 1
                 SET cluster.centre = t1.id
                 WITH t1

--- a/glove_nn.py
+++ b/glove_nn.py
@@ -76,8 +76,8 @@ def macro_vertex(macro_vertex_label, round=None):
 
         for row in result:
             cluster_id = row["cluster"]["id"]
-
-            session.run("""\
+            tx = session.begin_transaction()
+            tx.run("""\
                 MATCH (cluster:Cluster {id: $clusterId, round: $round })-[:CONTAINS]->(token)
                 WITH cluster, collect(token) AS tokens
                 UNWIND tokens AS t1 UNWIND tokens AS t2 WITH t1, t2, cluster WHERE t1 <> t2
@@ -88,7 +88,8 @@ def macro_vertex(macro_vertex_label, round=None):
                 CALL apoc.create.addLabels(t1, [$newLabel]) YIELD node
                 RETURN node
                 """, {"clusterId": cluster_id, "round": round, "newLabel": macro_vertex_label})
-
+            tx.success = True
+            tx.close()
 
 round = 0
 cluster_label = "Cluster"

--- a/glove_to_neo4j.py
+++ b/glove_to_neo4j.py
@@ -1,8 +1,8 @@
-from neo4j.v1 import GraphDatabase, basic_auth
+from neo4j import GraphDatabase, basic_auth
 
-driver = GraphDatabase.driver("bolt://localhost", auth=basic_auth("neo4j", "neo"))
+driver = GraphDatabase.driver("bolt://localhost", auth=basic_auth("neo4j", "neo"), encrypted=False)
 
-with open("data/medium_glove.txt", "r") as glove_file, driver.session() as session:
+with open("/data/medium_glove.txt", "r", encoding='utf-8') as glove_file, driver.session() as session:
     rows = glove_file.readlines()
 
     params = []
@@ -14,7 +14,7 @@ with open("data/medium_glove.txt", "r") as glove_file, driver.session() as sessi
         params.append({"id": id, "embedding": embedding})
 
     session.run("""\
-    UNWIND {params} AS row
+    UNWIND $params AS row
     MERGE (t:Token {id: row.id})
     ON CREATE SET t.embedding = row.embedding
     """, {"params": params})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+neo4j==1.7.1
 neo4j-driver==1.5.3
 numpy==1.14.3
-scikit-learn==0.19.1
+scikit-learn==0.20.1
 scipy==1.1.0


### PR DESCRIPTION
Libraries and code were updated to perform on Python 3.7 and Neo4j 3.4.17

There were the following errors (that were fixed):
- problems with libraries loading (because of absence of msvc compiler)
- not working driver for new Neo4j versions 3.x.x
- running of the one of queries was too long and exceed 15 minutes, so it was splitted to transactions